### PR TITLE
Fix workspace detection for pending CLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/wardzacharyj/SimpleCodeGen",
     "type": "git"
   },
-  "version": "0.0.1",
+  "version": "0.0.3",
   "engines": {
     "vscode": "^1.73.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,7 +41,8 @@ export const activate = (context: ExtensionContext) => {
         // 3. Allow user to select a change list destination
         let optionalChangeListNo: string|undefined = undefined;
         if (shouldUsePerforce) {
-            const selectedChangeListNo = await perforceChangeListInput(perforceSubscription.findWorkspacePendingChangeLists());
+            const wsPendingChangeLists = perforceSubscription.findWorkspacePendingChangeLists();
+            const selectedChangeListNo = await perforceChangeListInput(wsPendingChangeLists);
             if (!selectedChangeListNo) {
                 return;
             }


### PR DESCRIPTION
Uses node path library to resolve relative paths for determining what P4 workspace a path belongs to